### PR TITLE
Potential fix for code scanning alert no. 8: SQL query built from user-controlled sources

### DIFF
--- a/backend_service/app.py
+++ b/backend_service/app.py
@@ -58,7 +58,7 @@ def login():
     username = request.json.get("username")
     password = request.json.get("password")
 
-    rows = db.fetch_data(f"SELECT * FROM users where username='{username}' AND password='{password}'")
+    rows = db.fetch_data("SELECT * FROM users where username=? AND password=?", (username, password))
 
     if len(rows) != 1:
         return "Invalid credentials"

--- a/backend_service/utils/db_utils.py
+++ b/backend_service/utils/db_utils.py
@@ -5,22 +5,22 @@ class DatabaseUtils:
     def __init__(self, database_name='common_db.db'):
         self.database_name = database_name
     
-    def fetch_data(self, query):
+    def fetch_data(self, query, params=()):
         '''
         For select queries. Fetches data from the database and returns as a list of rows
         '''
         with sqlite3.connect(self.database_name) as conn:
             cursor = conn.cursor()
-            cursor.execute(query)
+            cursor.execute(query, params)
             rows = cursor.fetchall()
         return rows
     
-    def update_data(self, query):
+    def update_data(self, query, params=()):
         '''
         For all table modification queries which make changes to the database
         '''
         with sqlite3.connect(self.database_name) as conn:
             cursor = conn.cursor()
-            cursor.execute(query)
+            cursor.execute(query, params)
             conn.commit()
     


### PR DESCRIPTION
Potential fix for [https://github.com/CMPT785/A2-Backup/security/code-scanning/8](https://github.com/CMPT785/A2-Backup/security/code-scanning/8)

The best way to fix the problem is to use parameterized queries, which ensure that user input is properly escaped and cannot interfere with the structure of the SQL query. This can be achieved by modifying the `fetch_data` and `update_data` methods to accept query parameters separately from the query string. The `sqlite3` library supports parameterized queries using placeholders.

To implement the changes:
1. Modify the `fetch_data` and `update_data` methods to accept an additional `params` argument.
2. Use the `params` argument in the `execute` method to safely include user input in the query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
