### PR TITLE
Potential fix for code scanning alert no. 6: Uncontrolled data used in path expression

### DIFF
--- a/backend_service/utils/file_storage.py
+++ b/backend_service/utils/file_storage.py
@@ -14,17 +14,26 @@ class FileStorage(Storage):
             pass
     
     def store(self, filename, contents):
-        with open(self.storage_directory + '/' + filename, 'wb') as fp:
+        fullpath = os.path.normpath(os.path.join(self.storage_directory, filename))
+        if not fullpath.startswith(self.storage_directory):
+            raise Exception("Invalid file path")
+        with open(fullpath, 'wb') as fp:
             fp.write(contents)
     
     def get(self, filename):
-        with open(self.storage_directory + '/' + filename, 'rb') as fp:
+        fullpath = os.path.normpath(os.path.join(self.storage_directory, filename))
+        if not fullpath.startswith(self.storage_directory):
+            raise Exception("Invalid file path")
+        with open(fullpath, 'rb') as fp:
             contents = fp.read()
         return contents
     
     def delete(self, filename):
         try:
-            os.remove(self.storage_directory + '/' + filename)
+            fullpath = os.path.normpath(os.path.join(self.storage_directory, filename))
+            if not fullpath.startswith(self.storage_directory):
+                raise Exception("Invalid file path")
+            os.remove(fullpath)
             return 0
         except Exception as ex:
             return -1


### PR DESCRIPTION
Potential fix for [https://github.com/CMPT785/A2-Backup/security/code-scanning/6](https://github.com/CMPT785/A2-Backup/security/code-scanning/6)

To fix the problem, we need to ensure that the `filename` parameter is validated and sanitized before being used to construct file paths. The best way to do this is to normalize the path and ensure it is contained within the intended storage directory. We can use `os.path.normpath` to normalize the path and then check if the resulting path starts with the storage directory.

1. Normalize the `filename` using `os.path.normpath`.
2. Construct the full path using `os.path.join`.
3. Check if the normalized full path starts with the storage directory.
4. Raise an exception or handle the error if the path is not valid.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
